### PR TITLE
Update regex for Swiss VAT numbers to match new format based on Swiss BID number

### DIFF
--- a/internationalflavor/vat_number/data.py
+++ b/internationalflavor/vat_number/data.py
@@ -42,7 +42,7 @@ VAT_NUMBER_REGEXES = {
     'RU': r'^(\d{10}|\d{12})$',
     'SM': r'^\d{5}$',
     'RS': r'^\d{9}$',
-    'CH': r'^\d{9}$',
+    'CH': r'^\d{9}|E\d{9}(TVA|MWST|IVA)?$',
     'TR': r'^\d{10}$',
     'AR': r'^\d{11}$',
     # BO


### PR DESCRIPTION
Based on:
- https://www.ch.ch/en/value-added-tax-number-und-business-identification-number/
- https://en.wikipedia.org/wiki/VAT_identification_number
